### PR TITLE
Added a close

### DIFF
--- a/client/src/components/SettingsModal.vue
+++ b/client/src/components/SettingsModal.vue
@@ -9,6 +9,11 @@
                         @click="() => saveSettings(vote)">
                         <span>{{ vote.name }}</span>
                     </button>
+
+                  <button class="button"
+                          @click="close()">
+                    <span>Close</span>
+                  </button>
                 </div>
             </div>
         </div>
@@ -20,9 +25,13 @@ import GameFormat from '@/view-models/gameFormat';
 import { defineEmits } from 'vue';
 let gameFormats = JSON.parse(localStorage.getItem('gameTypes'));
 
-const emit = defineEmits(['saveSettings'])
+const emit = defineEmits(['saveSettings', 'close'])
 function saveSettings(vote: GameFormat) {
     emit('saveSettings', vote);
+}
+
+function close() {
+  emit('close');
 }
 </script>
 

--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -10,6 +10,7 @@
       v-if="settings"
       title="Settings"
       @saveSettings="saveSettings"
+      @close="settings = false"
     ></Settings>
     <Sharing v-if="showShareModal" title='share_modal_title' subTitle='share_modal_subtitle' @dismissModal="dismissModal"></Sharing>
     <div v-if="!modal && !settings && !showShareModal" class="home">


### PR DESCRIPTION
Added a close to the settings page. Currently there's no way to get out of the settings page unless you press back and then you have to rejoin the session.

The close is a bit ugly as it is in the share modal, but functionally it does the job.